### PR TITLE
add occultation supplemataire handling in jurinet utils

### DIFF
--- a/src/jurinet-utils.js
+++ b/src/jurinet-utils.js
@@ -398,6 +398,10 @@ class JurinetUtils {
       }
     }
 
+    if(!!document.OCCULTATION_SUPPLEMENTAIRE) {
+      normalizedDecision.occultation.additionalTerms = document.OCCULTATION_SUPPLEMENTAIRE;
+    }
+
     if (document.IND_BULLETIN === 1) {
       normalizedDecision.publication.push('B');
     }


### PR DESCRIPTION
The occultation supplementaire field was not defined and set in the additionalTerms of the normalizedDocument.

I noticed that the categoriesToOmit were not handled in the jurica-utils normalize function. The Jurica decisions are not concerned with the Nomos evolution ?