### PR TITLE
harmonizing log

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,10 @@ const path = require('path');
 require('dotenv').config({ quiet: true, path: path.join(__dirname, '..', '.env') });
 const { CustomLog } = require('./utils/logger');
 
-CustomLog.log('info', {
-  operationName: `Start`,
-  msg: `Start main script : ${new Date().toLocaleString()}`,
+CustomLog.info({
+  operations: ['other', `Start`],
+  path: 'src/index.js',
+  message: `Start main script : ${new Date().toLocaleString()}`,
 });
 
 if (process.env.SKIP_JOBS === 'false' || process.env.SKIP_JOBS === false) {
@@ -29,21 +30,24 @@ if (process.env.SKIP_JOBS === 'false' || process.env.SKIP_JOBS === false) {
     ],
   });
 
-  CustomLog.log('info', {
-    operationName: 'Start',
-    msg: 'Start jobs scheduler...',
+  CustomLog.info({
+    operations: ['other', 'Start'],
+    path: 'src/index.js',
+    message: 'Start jobs scheduler...',
   });
   const graceful = new Graceful({ brees: [bree] });
   graceful.listen();
   bree.start();
-  CustomLog.log('info', {
-    operationName: 'Start',
-    msg: 'Start jobs.',
+  CustomLog.info({
+    operations: ['other', 'Start'],
+    path: 'src/index.js',
+    message: 'Start jobs.',
   });
 } else {
-  CustomLog.log('info', {
-    operationName: 'Start',
-    msg: 'Skip jobs.',
+  CustomLog.info({
+    operations: ['other', 'Start'],
+    path: 'src/index.js',
+    message: 'Skip jobs.',
   });
   setInterval(() => {
     // nope

--- a/src/jobs/getSderId.js
+++ b/src/jobs/getSderId.js
@@ -1,26 +1,26 @@
 /**
  * 21/10/2025 - Julien Grach
- * 
+ *
  * JudilibreIndex en tant qu'outil de monitoring de décision a été remplacé par JuriPilot
- * 
- * JudilibreIndex comme gestionnaire d'exceptions est voué à être remplacé par un système plus robuste concernant 
+ *
+ * JudilibreIndex comme gestionnaire d'exceptions est voué à être remplacé par un système plus robuste concernant
  * l'entièreté des décisions (CC, CA mais aussi TJ, TCOM ...).
- * 
+ *
  * JudilibreIndex comme gestionnaire de l'affaire est voué à être remplacé par un système plus générique permettant également
  * le chaînage des termes de remplacements. On espère pouvoir tirer les timeline de ce nouveau projet plutôt que de JudilibreIndex.
- * 
+ *
  * Néanmoins, le travail du décommissionnement des affaires de judilibreIndex est en cours et ne sera pas fini sans reprise.
  * Il empêche de retrouver le SDER_ID et JURILIBRE_ID en direct depuis DBSDER à la réception d'une nouvelle décision.
  * Pour palier à ce problème et éviter des effets de bords non mesurés, je crée ce nouveau batch qui a pour objectif de récupérer
  * les ID DBSDER nouvellement crées et qui les positionnera dans JudilibreIndex.
  * Je fais ce travail sans avoir une pleine conscience de l'utilisation du SDER_ID et de JUDILIBRE_ID, notamment dans le reste du
  * système. Au mieux, il évitera les effets de bords, au pire, il est inutile. Ca reste un script sparadrap.
- * 
+ *
  * J'ose espérer cependant que nous pourrons rapidement décommissionner cet outil (judilibreIndex).
  */
 
-const { MongoClient } = require("mongodb");
-const { CustomLog } = require("../utils/logger");
+const { MongoClient } = require('mongodb');
+const { CustomLog } = require('../utils/logger');
 const path = require('path');
 require('dotenv').config({ quiet: true, path: path.join(__dirname, '..', '..', '.env') });
 
@@ -28,44 +28,66 @@ const dbsderClient = new MongoClient(process.env.MONGO_URI, { directConnection: 
 const indexClient = new MongoClient(process.env.INDEX_DB_URI, { directConnection: true });
 
 async function importDbsder() {
-    const YESTERDAY = new Date(Date.now() - 24 * 60 * 60 * 1000)
+  const YESTERDAY = new Date(Date.now() - 24 * 60 * 60 * 1000);
 
-    const client = await dbsderClient.connect()
-    const database = client.db(process.env.MONGO_DBNAME);
-    const decisions = database.collection(process.env.MONGO_DECISIONS_COLLECTION);
+  const client = await dbsderClient.connect();
+  const database = client.db(process.env.MONGO_DBNAME);
+  const decisions = database.collection(process.env.MONGO_DECISIONS_COLLECTION);
 
-    return decisions.find({ 
-        sourceName: { $in: ["jurinet", "jurica"] },
-        firstImportDate: { $gte: YESTERDAY.toISOString().split('T')[0] } })
+  return decisions.find({
+    sourceName: { $in: ['jurinet', 'jurica'] },
+    firstImportDate: { $gte: YESTERDAY.toISOString().split('T')[0] },
+  });
 }
 
 async function addSderIdToIndex(sourceId, sourceName, sderId) {
-    const jIndexConnection = await indexClient.connect()
-    const jIndexClient = jIndexConnection.db(process.env.INDEX_DB_NAME);
-    const jIndexMain = jIndexClient.collection('mainIndex');
+  const jIndexConnection = await indexClient.connect();
+  const jIndexClient = jIndexConnection.db(process.env.INDEX_DB_NAME);
+  const jIndexMain = jIndexClient.collection('mainIndex');
 
-    return jIndexMain.updateOne({ _id: `${sourceName}:${sourceId}`, sderId: null }, { $set: { sderId } })
+  return jIndexMain.updateOne({ _id: `${sourceName}:${sourceId}`, sderId: null }, { $set: { sderId } });
 }
 
 async function main() {
-    CustomLog.log("info", { operationName: "batch getSderId", msg: "starting getSderId" })
-    const cursor = await importDbsder()
+  CustomLog.info({
+    operations: ['other', 'batch getSderId'],
+    path: 'src/jobs/getSderId.js',
+    message: 'starting getSderId',
+  });
+  const cursor = await importDbsder();
 
-    for await (const doc of cursor) {
-        try {
-            const update = await addSderIdToIndex(doc.sourceId, doc.sourceName, doc._id)
-            if (update.modifiedCount > 0)
-                CustomLog.log("info", { operationName: "batch getSderId", msg: `sderId: ${doc._id} added to ${doc.sourceName}:${doc.sourceId}` })
-            else 
-                CustomLog.log("info", { operationName: "batch getSderId", msg: `sderId: ${doc._id} already known to ${doc.sourceName}:${doc.sourceId}` })
-        } catch (err) {
-            CustomLog.log("error", { operationName: "batch getSderId", msg: `error while adding sderId: ${doc._id} to ${doc.sourceName}:${doc.sourceId}`, data: err.stack})
-        }
+  for await (const doc of cursor) {
+    try {
+      const update = await addSderIdToIndex(doc.sourceId, doc.sourceName, doc._id);
+      if (update.modifiedCount > 0)
+        CustomLog.info({
+          operations: ['other', 'batch getSderId'],
+          path: 'src/jobs/getSderId.js',
+          message: `sderId: ${doc._id} added to ${doc.sourceName}:${doc.sourceId}`,
+        });
+      else
+        CustomLog.info({
+          operations: ['other', 'batch getSderId'],
+          path: 'src/jobs/getSderId.js',
+          message: `sderId: ${doc._id} already known to ${doc.sourceName}:${doc.sourceId}`,
+        });
+    } catch (err) {
+      CustomLog.error({
+        operations: ['other', 'batch getSderId'],
+        path: 'src/jobs/getSderId.js',
+        message: `error while adding sderId: ${doc._id} to ${doc.sourceName}:${doc.sourceId}`,
+        stack: err.stack,
+      });
     }
+  }
 }
 
-main().finally(async _ => {
-    dbsderClient.close()
-    indexClient.close()
-    CustomLog.log("info", { operationName: "batch getSderId", msg: `getSderId finished` })
-})
+main().finally(async (_) => {
+  dbsderClient.close();
+  indexClient.close();
+  CustomLog.info({
+    operations: ['other', 'batch getSderId'],
+    path: 'src/jobs/getSderId.js',
+    message: `getSderId finished`,
+  });
+});

--- a/src/jobs/import.js
+++ b/src/jobs/import.js
@@ -128,20 +128,22 @@ async function importJurinet() {
           row._indexed = null;
           if (raw === null) {
             await rawJurinet.insertOne(row, { bypassDocumentValidation: true });
-            CustomLog.log('info', {
-              operationName: 'ImportJurinetNew',
-              msg: `Jurinet insert new CC decision ${row._id})`,
-              data: {
+            CustomLog.info({
+              operations: ['other', 'ImportJurinetNew'],
+              path: 'src/jobs/import.js',
+              message: `Jurinet insert new CC decision ${row._id})`,
+              decision: {
                 sourceId: row._id,
                 sourceName: 'jurinet',
               },
             });
           } else {
             await rawJurinet.replaceOne({ _id: row._id }, row, { bypassDocumentValidation: true });
-            CustomLog.log('info', {
-              operationName: 'ImportJurinetAlreadyInserted',
-              msg: `Jurinet overwrite already inserted CC decision ${row._id}`,
-              data: {
+            CustomLog.info({
+              operations: ['other', 'ImportJurinetAlreadyInserted'],
+              path: 'src/jobs/import.js',
+              message: `Jurinet overwrite already inserted CC decision ${row._id}`,
+              decision: {
                 sourceId: row._id,
                 sourceName: 'jurinet',
               },
@@ -161,10 +163,11 @@ async function importJurinet() {
           await sendToJurinorm('CC', normDec);
           await jurinetSource.markAsImported(row._id);
 
-          CustomLog.log('info', {
-            operationName: 'ImportJurinetNormalize',
-            msg: `Jurinet CC decision normalized ${normDec.sourceName}, ${normDec.sourceId}`,
-            data: {
+          CustomLog.info({
+            operations: ['other', 'ImportJurinetNormalize'],
+            path: 'src/jobs/import.js',
+            message: `Jurinet CC decision normalized ${normDec.sourceName}, ${normDec.sourceId}`,
+            decision: {
               sourceId: normDec.sourceId,
               sourceName: normDec.sourceName,
               registerNumber: normDec.registerNumber,
@@ -187,22 +190,23 @@ async function importJurinet() {
           }
         } catch (e) {
           await jurinetSource.markAsErroneous(row._id);
-          CustomLog.log('warn', {
-            operationName: 'ImportJurinetError',
-            msg: `Error collecting Jurinet CC decision ${row._id}`,
-            data: {
+          CustomLog.warn({
+            operations: ['other', 'ImportJurinetError'],
+            path: 'src/jobs/import.js',
+            message: `Error collecting Jurinet CC decision ${row._id} - Error: ${e}`,
+            decision: {
               sourceId: row._id,
               sourceName: 'jurinet',
-              error: e,
             },
           });
           errorCount++;
         }
       } else {
-        CustomLog.log('warn', {
-          operationName: 'ImportJurinetSkip',
-          msg: `Jurinet skip already inserted CC decision ${row._id}`,
-          data: {
+        CustomLog.warn({
+          operations: ['other', 'ImportJurinetSkip'],
+          path: 'src/jobs/import.js',
+          message: `Jurinet skip already inserted CC decision ${row._id}`,
+          decision: {
             sourceId: row._id,
             sourceName: 'jurinet',
           },
@@ -221,10 +225,11 @@ async function importJurinet() {
         } catch (ignore) {}
       }
     } else {
-      CustomLog.log('warn', {
-        operationName: 'ImportJurinetSkip',
-        msg: `Jurinet skip non CC decision ${row._id}`,
-        data: {
+      CustomLog.warn({
+        operations: ['other', 'ImportJurinetSkip'],
+        path: 'src/jobs/import.js',
+        message: `Jurinet skip non CC decision ${row._id}`,
+        decision: {
           sourceId: row._id,
           sourceName: 'jurinet',
         },
@@ -238,9 +243,10 @@ async function importJurinet() {
   await jurinetSource.close();
   await juricaSource.close();
   await GRCOMSource.close();
-  CustomLog.log('info', {
-    operationName: 'ImportJurinetDone',
-    msg: `Done collect Jurinet - New: ${newCount}, Error: ${errorCount}, Skip: ${skipCount}.`,
+  CustomLog.info({
+    operations: ['other', 'ImportJurinetDone'],
+    path: 'src/jobs/import.js',
+    message: `Done collect Jurinet - New: ${newCount}, Error: ${errorCount}, Skip: ${skipCount}.`,
   });
   return true;
 }
@@ -441,20 +447,22 @@ async function importJurica() {
           row._indexed = null;
           if (raw === null) {
             await rawJurica.insertOne(row, { bypassDocumentValidation: true });
-            CustomLog.log('info', {
-              operationName: 'ImportJuricaNew',
-              msg: `Jurica insert new CA decision ${row._id})`,
-              data: {
+            CustomLog.info({
+              operations: ['other', 'ImportJuricaNew'],
+              path: 'src/jobs/import.js',
+              message: `Jurica insert new CA decision ${row._id})`,
+              decision: {
                 sourceId: row._id,
                 sourceName: 'jurica',
               },
             });
           } else {
             await rawJurica.replaceOne({ _id: row._id }, row, { bypassDocumentValidation: true });
-            CustomLog.log('info', {
-              operationName: 'ImportJuricaAlreadyInserted',
-              msg: `Jurica overwrite already inserted CA decision ${row._id}`,
-              data: {
+            CustomLog.info({
+              operations: ['other', 'ImportJuricaAlreadyInserted'],
+              path: 'src/jobs/import.js',
+              message: `Jurica overwrite already inserted CA decision ${row._id}`,
+              decision: {
                 sourceId: row._id,
                 sourceName: 'jurica',
               },
@@ -479,15 +487,15 @@ async function importJurica() {
           if (ShouldBeSentToJudifiltre === true) {
             normDec.labelStatus = 'ignored_controleRequis';
             normDec.publishStatus = 'blocked';
-            CustomLog.log('info', {
-              operationName: 'ImportJuricaBlocked',
-              msg: `Jurica CA decision blocked ${row._id}, ${row.JDEC_CODNAC}, ${row.JDEC_CODNACPART}, ${row.JDEC_IND_DEC_PUB}`,
-              data: {
+            CustomLog.info({
+              operations: ['other', 'ImportJuricaBlocked'],
+              path: 'src/jobs/import.js',
+              message: `Jurica CA decision blocked ${row._id}, ${row.JDEC_CODNAC}, ${row.JDEC_CODNACPART}, ${row.JDEC_IND_DEC_PUB}`,
+              decision: {
                 sourceId: row._id,
                 sourceName: 'jurica',
-                jdec_codnac: row.JDEC_CODNAC,
-                jdec_codnacpart: row.JDEC_CODNACPART,
-                jdec_ind_dec_pub: row.JDEC_IND_DEC_PUB,
+                publishStatus: normDec.publishStatus,
+                labelStatus: normDec.labelStatus,
               },
             });
           }
@@ -495,13 +503,14 @@ async function importJurica() {
           await sendToJurinorm('CA', normDec);
           await juricaSource.markAsImported(row._id);
 
-          CustomLog.log('info', {
-            operationName: 'ImportJuricaNormalize',
-            msg: `Jurica CA decision normalized ${normDec.sourceName}, ${normDec.sourceId}`,
-            data: {
+          CustomLog.info({
+            operations: ['other', 'ImportJuricaNormalize'],
+            path: 'src/jobs/import.js',
+            message: `Jurica CA decision normalized ${normDec.sourceName}, ${normDec.sourceId}, 
+              registerNumber: ${normDec.registerNumber}`,
+            decision: {
               sourceId: normDec.sourceId,
               sourceName: normDec.sourceName,
-              registerNumber: normDec.registerNumber,
               labelStatus: normDec.labelStatus,
               publishStatus: normDec.publishStatus,
               jurisdictionName: normDec.jurisdictionName,
@@ -512,10 +521,11 @@ async function importJurica() {
           await JuricaUtils.IndexAffaire(row, jIndexAffaires, jurinetSource.connection, decisions);
         } else {
           await juricaSource.markAsErroneous(row._id);
-          CustomLog.log('warn', {
-            operationName: 'ImportJuricaRejected',
-            msg: `Jurica import reject CA decision ${row._id}, ${row.JDEC_CODNAC}, ${row.JDEC_CODNACPART}, ${row.JDEC_IND_DEC_PUB}`,
-            data: {
+          CustomLog.warn({
+            operations: ['other', 'ImportJuricaRejected'],
+            path: 'src/jobs/import.js',
+            message: `Jurica import reject CA decision ${row._id}, ${row.JDEC_CODNAC}, ${row.JDEC_CODNACPART}, ${row.JDEC_IND_DEC_PUB}`,
+            decision: {
               sourceId: row._id,
               sourceName: 'jurica',
               jdec_codnac: row.JDEC_CODNAC,
@@ -527,22 +537,23 @@ async function importJurica() {
         }
       } catch (e) {
         await juricaSource.markAsErroneous(row._id);
-        CustomLog.log('warn', {
-          operationName: 'ImportJuricaError',
-          msg: `Error collecting Jurica CA decision ${row._id}`,
-          data: {
+        CustomLog.warn({
+          operations: ['other', 'ImportJuricaError'],
+          path: 'src/jobs/import.js',
+          message: `Error collecting Jurica CA decision ${row._id} - Error: ${e}`,
+          decision: {
             sourceId: row._id,
             sourceName: 'jurica',
-            error: e,
           },
         });
         errorCount++;
       }
     } else {
-      CustomLog.log('warn', {
-        operationName: 'ImportJuricaSkip',
-        msg: `Jurica skip already inserted CA decision ${row._id}`,
-        data: {
+      CustomLog.warn({
+        operations: ['other', 'ImportJuricaSkip'],
+        path: 'src/jobs/import.js',
+        message: `Jurica skip already inserted CA decision ${row._id}`,
+        decision: {
           sourceId: row._id,
           sourceName: 'jurica',
         },
@@ -566,9 +577,10 @@ async function importJurica() {
   await jIndexConnection.close();
   await juricaSource.close();
   await jurinetSource.close();
-  CustomLog.log('info', {
-    operationName: 'ImportJuricaDone',
-    msg: `Done collect Jurica - New: ${newCount}, Non-public: ${nonPublicCount}, Error: ${errorCount}, Skip: ${skipCount}.`,
+  CustomLog.info({
+    operations: ['other', 'ImportJuricaDone'],
+    path: 'src/jobs/import.js',
+    message: `Done collect Jurica - New: ${newCount}, Non-public: ${nonPublicCount}, Error: ${errorCount}, Skip: ${skipCount}.`,
   });
   return true;
 }
@@ -761,13 +773,13 @@ async function syncJurinet() {
               row.XMLA = null;
             }
             await rawJurinet.replaceOne({ _id: row._id }, row, { bypassDocumentValidation: true });
-            CustomLog.log('info', {
-              operationName: 'SyncJurinet',
-              msg: `Jurinet update CC decision ${row._id}`,
-              data: {
+            CustomLog.info({
+              operations: ['other', 'SyncJurinet'],
+              path: 'src/jobs/import.js',
+              message: `Jurinet update CC decision ${row._id} - Diff: ${JSON.stringify(changelog)}`,
+              decision: {
                 sourceId: row._id,
                 sourceName: 'jurinet',
-                changelog: changelog,
               },
             });
 
@@ -793,10 +805,11 @@ async function syncJurinet() {
             updateCount++;
             await sendToJurinorm('CC', normDec);
 
-            CustomLog.log('info', {
-              operationName: 'SyncJurinetNormalize',
-              msg: `Jurinet update normalized CC decision ${normDec.sourceName}, ${normDec.sourceId}`,
-              data: {
+            CustomLog.info({
+              operations: ['other', 'SyncJurinetNormalize'],
+              path: 'src/jobs/import.js',
+              message: `Jurinet update normalized CC decision ${normDec.sourceName}, ${normDec.sourceId}`,
+              decision: {
                 sourceId: normDec.sourceId,
                 sourceName: normDec.sourceName,
                 jurisdictionId: normDec.jurisdictionId,
@@ -817,10 +830,11 @@ async function syncJurinet() {
               );
             }
           } else {
-            CustomLog.log('warn', {
-              operationName: 'SyncJurinetSkip',
-              msg: `Jurinet skip no diff CC decision ${row._id}`,
-              data: {
+            CustomLog.warn({
+              operations: ['other', 'SyncJurinetSkip'],
+              path: 'src/jobs/import.js',
+              message: `Jurinet skip no diff CC decision ${row._id}`,
+              decision: {
                 sourceId: row._id,
                 sourceName: 'jurinet',
               },
@@ -829,10 +843,11 @@ async function syncJurinet() {
           }
         } else {
           await jurinetSource.markAsNew(row._id);
-          CustomLog.log('warn', {
-            operationName: 'SyncJurinetReset',
-            msg: `Jurinet reset non existing CC decision ${row._id}`,
-            data: {
+          CustomLog.warn({
+            operations: ['other', 'SyncJurinetReset'],
+            path: 'src/jobs/import.js',
+            message: `Jurinet reset non existing CC decision ${row._id}`,
+            decision: {
               sourceId: row._id,
               sourceName: 'jurinet',
             },
@@ -841,22 +856,23 @@ async function syncJurinet() {
         }
       } catch (e) {
         await jurinetSource.markAsErroneous(row._id);
-        CustomLog.log('warn', {
-          operationName: 'SyncJurinetError',
-          msg: `Error syncing Jurinet CC decision ${row._id}`,
-          data: {
+        CustomLog.warn({
+          operations: ['other', 'SyncJurinetError'],
+          path: 'src/jobs/import.js',
+          message: `Error syncing Jurinet CC decision ${row._id}, Error: ${e}`,
+          decision: {
             sourceId: row._id,
             sourceName: 'jurinet',
-            error: e,
           },
         });
         errorCount++;
       }
     } else {
-      CustomLog.log('warn', {
-        operationName: 'SyncJurinetSkip',
-        msg: `Jurinet skip non CC decision ${row._id}`,
-        data: {
+      CustomLog.warn({
+        operations: ['other', 'SyncJurinetSkip'],
+        path: 'src/jobs/import.js',
+        message: `Jurinet skip non CC decision ${row._id}`,
+        decision: {
           sourceId: row._id,
           sourceName: 'jurinet',
         },
@@ -880,9 +896,10 @@ async function syncJurinet() {
   await jurinetSource.close();
   await juricaSource.close();
   await GRCOMSource.close();
-  CustomLog.log('info', {
-    operationName: 'SyncJurinetDone',
-    msg: `Done syncing Jurinet - Update: ${updateCount}, Error: ${errorCount}, Skip: ${skipCount}.`,
+  CustomLog.info({
+    operations: ['other', 'SyncJurinetDone'],
+    path: 'src/jobs/import.js',
+    message: `Done syncing Jurinet - Update: ${updateCount}, Error: ${errorCount}, Skip: ${skipCount}.`,
   });
   return true;
 }
@@ -1133,13 +1150,13 @@ async function syncJurica() {
               row.HTMLA = null;
             }
             await rawJurica.replaceOne({ _id: row._id }, row, { bypassDocumentValidation: true });
-            CustomLog.log('info', {
-              operationName: 'SyncJurica',
-              msg: `Jurica update CA decision ${row._id}`,
-              data: {
+            CustomLog.info({
+              operations: ['other', 'SyncJurica'],
+              path: 'src/jobs/import.js',
+              message: `Jurica update CA decision ${row._id} - Diff: ${JSON.stringify(changelog)}`,
+              decision: {
                 sourceId: row._id,
                 sourceName: 'jurica',
-                changelog: changelog,
               },
             });
 
@@ -1161,15 +1178,13 @@ async function syncJurica() {
               normDec.labelStatus = 'ignored_controleRequis';
               normDec.publishStatus = 'blocked';
               normDec.labelTreatments = [];
-              CustomLog.log('info', {
-                operationName: 'SyncJuricaBlocked',
-                msg: `Jurica CA decision blocked following an update ${row._id}, ${row.JDEC_CODNAC}, ${row.JDEC_CODNACPART}, ${row.JDEC_IND_DEC_PUB}`,
-                data: {
+              CustomLog.info({
+                operations: ['other', 'SyncJuricaBlocked'],
+                path: 'src/jobs/import.js',
+                message: `Jurica CA decision blocked following an update ${row._id}, ${row.JDEC_CODNAC}, ${row.JDEC_CODNACPART}, ${row.JDEC_IND_DEC_PUB}`,
+                decision: {
                   sourceId: row._id,
                   sourceName: 'jurica',
-                  jdec_codnac: row.JDEC_CODNAC,
-                  jdec_codnacpart: row.JDEC_CODNACPART,
-                  jdec_ind_dec_pub: row.JDEC_IND_DEC_PUB,
                 },
               });
               await juricaSource.markAsImported(row._id);
@@ -1183,10 +1198,11 @@ async function syncJurica() {
             updateCount++;
             await sendToJurinorm('CA', normDec);
 
-            CustomLog.log('info', {
-              operationName: 'SyncJuricaNormalize',
-              msg: `Jurica update normalized CA decision ${normDec.sourceName} ${normDec.sourceId}`,
-              data: {
+            CustomLog.info({
+              operations: ['other', 'SyncJuricaNormalize'],
+              path: 'src/jobs/import.js',
+              message: `Jurica update normalized CA decision ${normDec.sourceName} ${normDec.sourceId}`,
+              decision: {
                 sourceId: normDec.sourceId,
                 sourceName: normDec.sourceName,
                 labelStatus: normDec.labelStatus,
@@ -1198,10 +1214,11 @@ async function syncJurica() {
 
             await JuricaUtils.IndexAffaire(row, jIndexAffaires, jurinetSource.connection, decisions);
           } else {
-            CustomLog.log('warn', {
-              operationName: 'SyncJuricaSkip',
-              msg: `Jurica skip no diff CA decision ${row._id}`,
-              data: {
+            CustomLog.warn({
+              operations: ['other', 'SyncJuricaSkip'],
+              path: 'src/jobs/import.js',
+              message: `Jurica skip no diff CA decision ${row._id}`,
+              decision: {
                 sourceId: row._id,
                 sourceName: 'jurica',
               },
@@ -1210,10 +1227,11 @@ async function syncJurica() {
           }
         } else {
           await juricaSource.markAsNew(row._id);
-          CustomLog.log('warn', {
-            operationName: 'SyncJuricaReset',
-            msg: `Jurica reset non existing CA decision ${row._id}`,
-            data: {
+          CustomLog.warn({
+            operations: ['other', 'SyncJuricaReset'],
+            path: 'src/jobs/import.js',
+            message: `Jurica reset non existing CA decision ${row._id}`,
+            decision: {
               sourceId: row._id,
               sourceName: 'jurica',
             },
@@ -1222,28 +1240,26 @@ async function syncJurica() {
         }
       } catch (e) {
         await juricaSource.markAsErroneous(row._id);
-        CustomLog.log('warn', {
-          operationName: 'SyncJuricaError',
-          msg: `Error syncing Jurica CA decision ${row._id}`,
-          data: {
+        CustomLog.warn({
+          operations: ['other', 'SyncJuricaError'],
+          path: 'src/jobs/import.js',
+          message: `Error syncing Jurica CA decision ${row._id} - Error: ${e}`,
+          decision: {
             sourceId: row._id,
             sourceName: 'jurica',
-            error: e,
           },
         });
         errorCount++;
       }
     } else {
       await juricaSource.markAsErroneous(row._id);
-      CustomLog.log('warn', {
-        operationName: 'SyncJuricaRejected',
-        msg: `Jurica sync reject CA decision ${row._id}, ${row.JDEC_CODNAC}, ${row.JDEC_CODNACPART}, ${row.JDEC_IND_DEC_PUB}`,
-        data: {
+      CustomLog.warn({
+        operations: ['other', 'SyncJuricaRejected'],
+        path: 'src/jobs/import.js',
+        message: `Jurica sync reject CA decision ${row._id}, ${row.JDEC_CODNAC}, ${row.JDEC_CODNACPART}, ${row.JDEC_IND_DEC_PUB}`,
+        decision: {
           sourceId: row._id,
           sourceName: 'jurica',
-          jdec_codnac: row.JDEC_CODNAC,
-          jdec_codnacpart: row.JDEC_CODNACPART,
-          jdec_ind_dec_pub: row.JDEC_IND_DEC_PUB,
         },
       });
       nonPublicCount++;
@@ -1264,9 +1280,10 @@ async function syncJurica() {
   await jIndexConnection.close();
   await juricaSource.close();
   await jurinetSource.close();
-  CustomLog.log('info', {
-    operationName: 'SyncJuricaDone',
-    msg: `Done syncing Jurica - Update: ${updateCount}, Non-public: ${nonPublicCount}, Error: ${errorCount}, Skip: ${skipCount}.`,
+  CustomLog.info({
+    operations: ['other', 'SyncJuricaDone'],
+    path: 'src/jobs/import.js',
+    message: `Done syncing Jurica - Update: ${updateCount}, Non-public: ${nonPublicCount}, Error: ${errorCount}, Skip: ${skipCount}.`,
   });
   return true;
 }

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,64 +1,80 @@
-const pino = require("pino");
+const pino = require('pino');
 // Configuration pour Pino en local
 const pinoPrettyConf = {
-    transport: {
-        target: "pino-pretty",
-        options: {
-            singleLine: true,
-            colorize: true,
-            translateTime: "SYS:dd-mm-yyyy - HH:MM:ss Z",
-        },
+  transport: {
+    target: 'pino-pretty',
+    options: {
+      singleLine: true,
+      colorize: true,
+      translateTime: 'SYS:dd-mm-yyyy - HH:MM:ss Z',
     },
+  },
 };
 
 // Configuration principale pour Pino
 const PinoConfig = {
-    base: { appName: "OpenJustice-sder" },
-    formatters: {
-        level: (label) => ({
-            logLevel: label.toUpperCase(),
-        }),
-    },
-    timestamp: () => `,"timestamp":"${new Date(Date.now()).toLocaleString()}"`,
-    redact: {
-        paths: ["req", "res", "headers", "ip", "responseTime", "pid", "level"],
-        censor: "",
-        remove: true,
-    },
-    transport: process.env.NODE_ENV === "local" ? pinoPrettyConf.transport : undefined,
-    autoLogging: false,
+  base: { appName: 'OpenJustice-sder' },
+  formatters: {
+    level: (label) => ({
+      logLevel: label.toUpperCase(),
+    }),
+  },
+  timestamp: () => `,"timestamp":"${new Date(Date.now()).toLocaleString()}"`,
+  redact: {
+    paths: ['req', 'res', 'headers', 'ip', 'responseTime', 'pid', 'level'],
+    censor: '',
+    remove: true,
+  },
+  transport: process.env.NODE_ENV === 'local' ? pinoPrettyConf.transport : undefined,
+  autoLogging: false,
 };
 
 // Initialisation du logger Pino
 const logger = pino(PinoConfig);
+// types definition for log details
+/**
+ * @typedef {Object} DecisionLog
+ * @property {Object} decision
+ * @property {string} [decision._id]
+ * @property {string} decision.sourceId
+ * @property {string} decision.sourceName
+ * @property {string} [decision.publishStatus]
+ * @property {string} [decision.labelStatus]
+ * @property {string} [decision.jurisdictionId]
+ * @property {string} [decision.jurisdictionName]
+ * @property {string} path
+ * @property {[('collect'|'extraction'|'normalization'|'other'), string]} operations
+ * @property {string} [message]
+ */
+
+/**
+ * @typedef {Object} TechLog
+ * @property {string} path
+ * @property {[('collect'|'extraction'|'normalization'|'other'), string]} operations
+ * @property {string} [message]
+ */
 
 class CustomLog {
-    // Méthode pour générer un objet de log structuré
-    static createLog({
-        operationName,
-        msg,
-        data,
-        httpMethod,
-        path,
-        correlationId,
-        statusCode,
-    } = {}) {
-        return {
-            operationName,
-            msg,
-            data,
-            httpMethod,
-            path,
-            correlationId,
-            statusCode,
-        };
-    }
+  /**
+   * @param {DecisionLog | TechLog} data
+   */
+  static info(data) {
+    logger.info(data);
+  }
 
-    // Méthode utilitaire pour journaliser avec un format structuré
-    static log(level = "info", logDetails = {}) {
-        const logEntry = this.createLog(logDetails);
-        logger[level](logEntry);
-    }
+  /**
+   * @param {TechLog & {stack?: string}} data
+   */
+  static error(data) {
+    logger.error(data);
+  }
+
+  /**
+   * @param {DecisionLog | TechLog} data
+   */
+  static warn(data) {
+    logger.warn(data);
+  }
 }
 
-module.exports = { CustomLog };
+module.exports = { CustomLog, logger };


### PR DESCRIPTION
Nous avons deux types de log : techlog => pour logger les erreurs et decisionlog pour logger les informations sur le traitement d'une decision 
```
export type DecisionLog = {
  decision: {
    _id?: string;
    sourceId: string;
    sourceName: string;
    publishStatus?: string;
    labelStatus?: string;
  };
  path: string;
  operations: readonly ['collect' | 'extraction' | 'normalization' | 'other', string];
  message?: string;
};

export type TechLog = {
  path: string;
  operations: readonly ['collect' | 'extraction' | 'normalization' | 'other', string];
  message?: string;
};
```